### PR TITLE
docs: fix parsing errors

### DIFF
--- a/docs/dashboard/complete-profile.mdx
+++ b/docs/dashboard/complete-profile.mdx
@@ -17,7 +17,6 @@ All ZBD users have a ZBD Gamertag associated with their account, even Developers
 Think of this as a username for your account. You can change your Gamertag at any time by following the steps in the **Account > Profile** sections.
 
 <Tip>Did you know that creating a Developer account also creates a [**ZBD**](https://zbd.gg) App account?
-
 You can use the same login information for your [ZEBEDEE Developer Dashboard](https://dashboard.zebedee.io) account on the ZBD App. Although the ZBD Gamertag is shared between these accounts, each has a separate Bitcoin wallet for fund segregation!</Tip>
 
 ## Upload Profile Image[​](#upload-profile-image "Direct link to heading")

--- a/docs/dashboard/projects/sandbox.mdx
+++ b/docs/dashboard/projects/sandbox.mdx
@@ -38,7 +38,6 @@ If you ever find yourself running low on _fake satoshis_ you can always top up y
 <br />
 
 <Note>Currently the Top Up functionality for Sandbox Project Wallets is fixed at increments of 10,000 satoshis. Given this is for testing purposes you should have more than enough to test your integration.
-
 You may top up as many times as you'd like.</Note>
 
 ## Sandbox APIs[​](#sandbox-apis "Direct link to heading")
@@ -48,7 +47,6 @@ As is expected, Sandbox Projects have their own Sandbox APIs and API Keys. These
 You can view all Sandbox APIs by heading over to the [Sandbox API Reference page](/api/sandbox/gamertag/send-payment).
 
 <Note>At the moment we have exposed the [**Send Bitcoin to ZBD Gamertag Sandbox API**](/api/sandbox/gamertag/send-payment) for testing purposes. We will be adding more Sandbox APIs in the future, including the ability to create Sandbox Charges and Static Charges, as well as send Sandbox Payments.
-
 **If you're looking to leverage any of the other ZEBEDEE Payment APIs, go through the Identity Verification Process and swap to a Live Project.**</Note>
 
 ## Sending Bitcoin to a Sandbox ZBD Gamertag[​](#sending-bitcoin-to-a-sandbox-zbd-gamertag "Direct link to heading")

--- a/docs/dashboard/projects/wallet.mdx
+++ b/docs/dashboard/projects/wallet.mdx
@@ -15,7 +15,6 @@ Each `Project` wallet is a distinct and fully-enabled Bitcoin Lightning wallet, 
 Any payments made using this Project’s API key will debit this Project wallet. You can easily transfer funds from one project wallet to another.
 
 <Tip>**Project wallets are distinct from your Developer wallet.** Your developer wallet is associated with your profile, while project wallets are generated whenever you create a new project.
-
 Your Developer wallet is akin to a central management account and the project wallet as being an individual app account.</Tip>  
 
 Fund a Project Wallet by:


### PR DESCRIPTION
A few pages didn't parse properly. Fixed those.

If anyone ever runs into similar issues: [Callouts](https://mintlify.com/docs/content/components/callouts) can't handle empty lines.