### PR TITLE
Update Android attestation steps & fix Apple typo

### DIFF
--- a/earn/sdk/attestation-setup.mdx
+++ b/earn/sdk/attestation-setup.mdx
@@ -37,17 +37,12 @@ To find your app's SHA-256 hash key for Google Play:
     <Step title="Select your app">
         Choose the app for which you need the SHA-256 hash.
     </Step>
-    <Step title="Navigate to Release">
-        Go to the Release section in the left-hand menu.
+    <Step title="Navigate to Protected with Play">
+        In the left-hand menu, select Protected with Play.
     </Step>
-    <Step title="Navigate to Setup">
-        Click on Setup in the submenu.
+    <Step title="Go to Play Store protection">
     </Step>
-    <Step title="Select App integrity from the options">
-
-    </Step>
-    <Step title=" Click on App signing">
-
+    <Step title="Click on Manage Play app signing">
     </Step>
     <Step title="Find the App signing key certificate">
     </Step>
@@ -97,7 +92,7 @@ To enable App Attest:
 For iOS we need your **Bundle ID** i.e.`app id`, e.g.`com.domain.appname` and your **Team ID**.
 To find your app's Team ID for Apple Developer:
 <Steps>
-    <Step title="Access Appel Developer Account">
+    <Step title="Access Apple Developer Account">
         Sign in to your Apple Developer account
     </Step>
     <Step title="Click on Membershipt details">


### PR DESCRIPTION
## What changed

Updates to `earn/sdk/attestation-setup.mdx`:

1. **Rewrote the Google Play SHA-256 lookup steps** to match the current Play Console navigation. The old path (`Release → Setup → App integrity → App signing`) no longer reflects the console UI; the new path is **Protected with Play → Play Store protection → Manage Play app signing**.
2. **Fixed a typo:** "Access **Appel** Developer Account" → "Access **Apple** Developer Account" (iOS Team ID step).

## Why

The Android attestation instructions pointed users down a console menu path that Google has since restructured, and the iOS section had a visible misspelling.

## Reviewer notes

- ⚠️ **Follow-up pending:** the screenshot `img/earn/google-play-attestation.png` still shows the **old** Google Play UI. It should be replaced with the new "Protected with Play" screenshot to match the updated steps. Not included here because the image file wasn't available at commit time — happy to add it in a follow-up commit to this PR.
- Verified locally (`mint dev`): the new steps render and the old `Release`/`App integrity` steps and the `Appel` typo are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)