### PR TITLE
docs: add EU Pricing Policy link to footer

### DIFF
--- a/snippets/footer.mdx
+++ b/snippets/footer.mdx
@@ -1,3 +1,5 @@
+const EU_PRICING_POLICY_URL = "https://cdn.zebedee.io/legal-docs/eu-pricing-policy/ZEBEDEE+EUROPE+B.V.+-+Website+Pricing+Policy+v1.0.pdf"
+
 export const Footer = () => {
   return (
     <div className="max-w-md p-2 pt-8 space-y-0">
@@ -26,6 +28,16 @@ export const Footer = () => {
           LLM?{" "}
           <a href="/llms.txt" className="text-[#1659e7]">
             Read llms.txt
+          </a>
+          .
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <p className="text-sm mb-0">
+          Read our{" "}
+          <a href={EU_PRICING_POLICY_URL} target="_blank" className="text-[#1659e7]">
+            EU Pricing Policy
           </a>
           .
         </p>


### PR DESCRIPTION
Add a link to the ZEBEDEE EU Pricing Policy PDF in the site footer, pointing to the legal document hosted on the CDN.

### Validation
- `mintlify broken-links` was run — the new EU Pricing Policy link resolves correctly and is not broken.
- 5 unrelated pre-existing broken links remain (unaffected by this change).