### PR TITLE
Link Earn API card to Payments API page

### DIFF
--- a/get-started.mdx
+++ b/get-started.mdx
@@ -70,7 +70,7 @@ Drive user engagement, boost retention, and unlock new revenue streams by offeri
       Unity SDK for adding real-money rewards to your games. Drag, drop, monetize.
     </p>
   </Card>
-  <Card title="Earn API" horizontal icon='terminal' href="/earn/api">
+  <Card title="Earn API" horizontal icon='terminal' href="/payments/api">
     <p>
       Programmatically distribute rewards. Perfect for tournaments and achievements.
     </p>


### PR DESCRIPTION
The Earn API card on the Getting Started page pointed at /earn/api (which redirects to the Earn SDK). Point it at /payments/api so it lands on the actual API reference.