### PR TITLE
docs(widget): outstanding disclosures on user creation + iframe allow-downloads

### DIFF
--- a/widget.mdx
+++ b/widget.mdx
@@ -77,6 +77,7 @@ After creating a session, load the returned `widget_url` in your client. Your ba
       src="https://widget.zbd.gg/?session_token=eyJhbGci..."
       style="width: 100%; height: 600px; border: none;"
       allow="camera; microphone"
+      sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
     ></iframe>
     ```
   </Tab>
@@ -124,6 +125,10 @@ After creating a session, load the returned `widget_url` in your client. Your ba
     ```
   </Tab>
 </Tabs>
+
+<Warning>
+  **Allow document downloads.** The widget lets users download documents (disclosure PDFs, cashout receipts/statements). Browsers only permit a framed page to start a download if the iframe explicitly allows it. If you apply a `sandbox` attribute — as in the example above — it **must** include **`allow-downloads`** (alongside `allow-scripts allow-same-origin allow-forms allow-popups`). Without `allow-downloads`, the browser blocks the in-frame download and the widget falls back to opening the document in a **new browser tab**. If you do not set a `sandbox` attribute at all, downloads work by default.
+</Warning>
 
 ## Embed Parameters
 

--- a/widget/create-user.mdx
+++ b/widget/create-user.mdx
@@ -48,6 +48,18 @@ curl -X POST https://api.zbdpay.com/api/v1/widget/users \
 ```
 </RequestExample>
 
+## Response
+
+The response `data` includes the new (or existing) user plus an `outstanding_disclosures` array — the disclosure versions this user still needs to accept. This is returned on the **first user request**, so you have the user's outstanding disclosures immediately, with no extra call.
+
+<ResponseField name="outstanding_disclosures" type="array">
+  Disclosure versions the user has not yet accepted. Empty when the user is current on all disclosures. Each entry includes `id`, `type_id`, `name`, `description`, `version`, `content_uri`, `created_at`, and `due_date`.
+</ResponseField>
+
+<Note>
+  `outstanding_disclosures` lists only what is still outstanding. To list a user's full acceptance state (including what they have **already accepted**), call [Get Disclosure Status](/widget/get-disclosure-status) at any time. See [Disclosure Agreements](/widget/disclosures) for the full model.
+</Note>
+
 <ResponseExample>
 ```json 201
 {
@@ -55,7 +67,19 @@ curl -X POST https://api.zbdpay.com/api/v1/widget/users \
   "data": {
     "id": "4ac4fd8a-cc2c-4d03-af09-a76f4e89d652",
     "reference_id": "player-42",
-    "email": "player@example.com"
+    "email": "player@example.com",
+    "outstanding_disclosures": [
+      {
+        "id": 12,
+        "type_id": 2,
+        "name": "Terms of Service",
+        "description": "ZBD Terms of Service Document.",
+        "version": "1.4.0",
+        "content_uri": "https://...",
+        "created_at": "2026-06-24T20:11:45Z",
+        "due_date": "2025-08-11T00:00:00"
+      }
+    ]
   }
 }
 ```

--- a/widget/disclosures.mdx
+++ b/widget/disclosures.mdx
@@ -25,6 +25,19 @@ The widget session exposes outstanding session disclosures, and the cashout back
   If your integration only embeds the hosted widget, the disclosure prompt and acceptance flow are handled inside the widget. Your backend still creates users, funds balances, creates sessions, and processes webhooks as usual.
 </Info>
 
+## Outstanding Disclosures on User Creation
+
+You do not need a separate call to discover what a user still owes. The [Create User](/widget/create-user) response (`POST /api/v1/widget/users`) already includes an **`outstanding_disclosures`** array on that **first user request** — the disclosure versions this user has not yet accepted. Surface or record them right away; if the array is empty, the user is current.
+
+`outstanding_disclosures` only lists what is **still outstanding**. When you need the complete picture — including which disclosures a user has **already accepted** and when — use the dedicated endpoints:
+
+- [Get Disclosure Status](/widget/get-disclosure-status) — list every current disclosure type with the user's acceptance state (`is_current`, `accepted_at`), so you can show accepted vs. outstanding.
+- [Submit Disclosure Acceptance](/widget/submit-disclosure-acceptance) — record acceptance of the latest version from your server.
+
+<Note>
+  The same `outstanding_disclosures` shape also appears in the widget session status during a session (see [Session Status](#session-status)). Create User is the initial snapshot at provisioning time; Get Disclosure Status is the source of truth for the full, up-to-date acceptance state.
+</Note>
+
 ## Disclosure Types
 
 The widget disclosure endpoints can check and record acceptance for all current disclosure types.


### PR DESCRIPTION
## What

Follow-up to #101 (merged). Adds one commit (`68dc2ba`) documenting two things surfaced while building the widget disclosure + cashout flow.

### 1. Widget embed — require `allow-downloads` in the iframe sandbox
The widget lets users download documents (disclosure PDFs, cashout receipts/statements). Browsers only permit a framed page to start a download if the iframe explicitly allows it. The embed example and a new callout now state that if a `sandbox` attribute is applied it **must** include **`allow-downloads`**. Without it, the browser blocks the in-frame download and the widget falls back to opening the document in a **new browser tab**. (No `sandbox` attribute at all → downloads work by default.)

### 2. `outstanding_disclosures` on user creation
- **create-user**: documents the `outstanding_disclosures` array returned on the **first user request** (fields + example), with a pointer to Get Disclosure Status for the full accepted/outstanding state.
- **disclosures**: new "Outstanding Disclosures on User Creation" section, plus the endpoints for listing accepted vs. outstanding.

## Files
- `widget.mdx` — iframe `allow-downloads` example + callout
- `widget/create-user.mdx` — Response section + `outstanding_disclosures` example
- `widget/disclosures.mdx` — new outstanding-on-creation section

Docs-only; no code changes.
