### PR TITLE
Rename dashboard "SDK" labels to "Earn"

### DIFF
--- a/earn/sdk/manage-controls-dashboard.mdx
+++ b/earn/sdk/manage-controls-dashboard.mdx
@@ -1,6 +1,6 @@
 ---
-title: "SDK Controls (Dashboard)"
-sidebarTitle: "SDK Controls"
+title: "Earn Controls (Dashboard)"
+sidebarTitle: "Earn Controls"
 description: "Override a player's detected country and manage your project whitelist from the ZBD Developer Dashboard."
 icon: "users-gear"
 ---
@@ -12,7 +12,7 @@ ZBD detects a player's country automatically from their IP address. This determi
 - A player is in an unsupported region but you want to whitelist them for testing
 - Your QA team needs to test from a region other than their own
 
-Use this page for those cases. Access it via [dashboard.zbdpay.com](https://dashboard.zbdpay.com) under **SDK User Support**.
+Use this page for those cases. Access it via [dashboard.zbdpay.com](https://dashboard.zbdpay.com) under **Earn User Support**.
 
 ## Find a player
 
@@ -40,7 +40,7 @@ Override a player's detected country — for example if their IP is flagged inco
 
 Whitelisting allows a specific player to access your rewards program from a region that would otherwise be blocked — for example, a member of your QA team based in an unsupported country.
 
-1. Go to the **Whitelist User** card below the SDK User ID card
+1. Go to the **Whitelist User** card below the Earn User ID card
 2. Enter the player's **Support ID**
 3. Select the **Rewards App Name** tied to that Support ID
 4. Click **Whitelist**

--- a/earn/sdk/manage-rewards-balance.mdx
+++ b/earn/sdk/manage-rewards-balance.mdx
@@ -10,7 +10,7 @@ Use the ZBD Developer Dashboard to manually adjust a player's rewards balance �
 ## Find the player
 
 1. Go to [dashboard.zbdpay.com](https://dashboard.zbdpay.com)
-2. Navigate to **SDK User Support** in the sidebar
+2. Navigate to **Earn User Support** in the sidebar
 3. Search by one of the following:
    - **`rewardsUserId`** — the player's SDK identifier, returned by `GetUserStatus`. Loads the player directly.
    - **Support ID** — a player-facing identifier shown in the ZBD modal, used when a player contacts your support team. Returns a list of matching players.

--- a/earn/sdk/manage-user-linking.mdx
+++ b/earn/sdk/manage-user-linking.mdx
@@ -9,13 +9,13 @@ Manage user linking to ZBD gamertags through the ZBD Dashboard.
 ## Access
 
 1. Go to [dashboard.zbdpay.com](https://dashboard.zbdpay.com)
-2. Navigate to **SDK User Support** in the sidebar
+2. Navigate to **Earn User Support** in the sidebar
 
 ## Search Users
 
 Enter one of the following in the search field:
 
-- **SDK User ID** → Loads user data directly
+- **Earn User ID** → Loads user data directly
 - **Support ID** → Shows list of users with that linked ID → select one
 - **Gamertag** → Shows list of users with that gamertag → select one
 

--- a/earn/sdk/manage-via-dashboard.mdx
+++ b/earn/sdk/manage-via-dashboard.mdx
@@ -6,12 +6,12 @@ icon: "sliders"
 
 Manage your Rewards App settings directly from the ZBD Dashboard.
 
-## Access Your Project's SDK Settings
+## Access Your Project's Earn Settings
 
 1. Go to [dashboard.zbdpay.com](https://dashboard.zbdpay.com)
 2. Navigate to **Projects**
 3. Select your project
-4. Click the **SDK** tab
+4. Click the **Earn** tab
 5. Click the **Controls** sub-tab
 
 Your Rewards App settings will load automatically under **API Key Control** and **Client Send Control** sections.
@@ -28,7 +28,7 @@ To send rewards from your server, you need an API key for authentication.
 
 ### How to Create
 
-1. In the SDK tab → Controls sub-tab, find the **API Key Control** section
+1. In the Earn tab → Controls sub-tab, find the **API Key Control** section
 2. Check the **Status** badge:
    - 🔴 **Disabled** (red) with text "No active API key found" = No API key exists
    - 🟢 **Enabled** (green) = API key is active
@@ -56,7 +56,7 @@ After creating your API key, you can disable client-side reward sending to enfor
 
 ### How to Disable Client-Side Sending
 
-1. In the SDK tab, find the **Client Send Control** section
+1. In the Earn tab, find the **Client Send Control** section
 2. Check the **Status** badge:
    - 🟢 **Enabled** (green) with text "Client sending is enabled" = Client can send rewards
    - 🔴 **Disabled** (red) with text "Client sending is disabled" = Only server can send
@@ -82,7 +82,7 @@ If your API key is compromised or no longer needed, revoke it immediately.
 
 ### How to Revoke
 
-1. In the SDK tab, find the **API Key Control** section
+1. In the Earn tab, find the **API Key Control** section
 2. Make sure the Status is 🟢 **Enabled** (green)
 3. Click **"Revoke Key"** button
 4. Confirm the action in the dialog

--- a/earn/sdk/manage-withdrawal-limits.mdx
+++ b/earn/sdk/manage-withdrawal-limits.mdx
@@ -9,13 +9,13 @@ Manage user withdrawal limits through the ZBD Dashboard.
 ## Access
 
 1. Go to [dashboard.zbdpay.com](https://dashboard.zbdpay.com)
-2. Navigate to **SDK User Support** in the sidebar
+2. Navigate to **Earn User Support** in the sidebar
 
 ## Search Users
 
 Enter one of the following in the search field:
 
-- **SDK User ID** → Loads user data directly
+- **Earn User ID** → Loads user data directly
 - **Support ID** → Shows list of users with that linked ID → select one
 - **Gamertag** → Shows list of users with that gamertag → select one
 

--- a/earn/sdk/security.mdx
+++ b/earn/sdk/security.mdx
@@ -15,7 +15,7 @@ ZBD detects a player's country from their IP address on SDK initialization. This
 - What withdrawal limits apply (Tier 1 countries like the US, UK, and DE have higher limits than Tier 2 countries)
 - Whether the player is in a supported region at all
 
-If a player's detected country is incorrect — due to a VPN, travel, or a bad IP lookup — you can override it from the developer dashboard. See [SDK Controls](/earn/sdk/manage-controls-dashboard).
+If a player's detected country is incorrect — due to a VPN, travel, or a bad IP lookup — you can override it from the developer dashboard. See [Earn Controls](/earn/sdk/manage-controls-dashboard).
 
 ## VPN and proxy detection
 

--- a/earn/sdk/send-rewards-server.mdx
+++ b/earn/sdk/send-rewards-server.mdx
@@ -29,8 +29,8 @@ If you exceed this limit, you will receive a `429 Too Many Requests` response. I
 ## How It Works
 
 <Steps>
-    <Step title="Access Your Project's SDK Settings">
-        Go to Dashboard → Projects → Select Your Project → SDK tab → Controls sub-tab.
+    <Step title="Access Your Project's Earn Settings">
+        Go to Dashboard → Projects → Select Your Project → Earn tab → Controls sub-tab.
 
         Your Rewards App settings will load automatically.
     </Step>


### PR DESCRIPTION
The dev dashboard renamed the SDK tab (and related labels) to Earn, but the docs still referenced the old names. Updated all dashboard-label references across the Earn SDK pages:

- SDK tab -> Earn tab
- SDK Settings -> Earn Settings
- SDK User Support -> Earn User Support
- SDK User ID -> Earn User ID
- SDK Controls -> Earn Controls (page title/sidebar + inbound link)

Left genuine SDK references untouched (the Unity SDK itself, client SDK, Earn SDK product name, rewardsUserId descriptions, URL paths).